### PR TITLE
Fix scroll length for before-after images

### DIFF
--- a/style.css
+++ b/style.css
@@ -613,7 +613,12 @@ ul h3 {
   margin-top: 2rem;
   border-radius: 12px;
   overflow: hidden;
-  height: 100%;
+  /*
+     Allow the jQuery twentytwenty plugin to set the container height based on
+     the image dimensions. Otherwise the container height is locked to the
+     scroll-wrapper height and the image gets cut off when scrolling.
+   */
+  height: auto;
     display: flex;
   align-items: center;
   justify-content: center;
@@ -635,6 +640,14 @@ ul h3 {
 .twentytwenty-container img {
   width: 100%;
   height: auto;
+}
+
+/*
+  When the before image is shorter than the after image, show a white
+  background in the uncovered area so the slider transition looks clean.
+*/
+.twentytwenty-before {
+  background-color: #fff;
 }
 
 .twentytwenty-wrapper {

--- a/vendor/twentytwenty/js/jquery.twentytwenty.js
+++ b/vendor/twentytwenty/js/jquery.twentytwenty.js
@@ -40,7 +40,9 @@
       
       var calcOffset = function(dimensionPct) {
         var w = beforeImg.width();
-        var h = beforeImg.height();
+        // Use the taller image height so the container can fit the
+        // entire "after" image even if the "before" image is shorter.
+        var h = Math.max(beforeImg.height(), afterImg.height());
         return {
           w: w+"px",
           h: h+"px",
@@ -101,7 +103,8 @@
         offsetX = container.offset().left;
         offsetY = container.offset().top;
         imgWidth = beforeImg.width(); 
-        imgHeight = beforeImg.height();          
+        // Track the tallest image height for correct slider calculations
+        imgHeight = Math.max(beforeImg.height(), afterImg.height());
       };
       var onMove = function(e) {
         if (container.hasClass("active")) {
@@ -137,7 +140,7 @@
           offsetX = container.offset().left;
           offsetY = container.offset().top;
           imgWidth = beforeImg.width();
-          imgHeight = beforeImg.height();
+          imgHeight = Math.max(beforeImg.height(), afterImg.height());
 
           sliderPct = getSliderPercentage(e.pageX, e.pageY);
           adjustSlider(sliderPct);


### PR DESCRIPTION
## Summary
- use the taller of the two images when sizing the before/after container
- paint the short image's uncovered area white

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ebea6f81c832883bab684065ff38e